### PR TITLE
chore(dependabot): create new group for release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
           - 'astro'
         update-types:
           - 'major'
+          - 'minor'
+      release:
+        patterns:
+          - '*commitlint*'
+          - '*semantic-release*'
+        update-types:
+          - 'major'
+          - 'minor'
       eslint:
         patterns:
           - '*eslint*'


### PR DESCRIPTION
Add new group for commitlint and semantic-release to the dependabot configuration.